### PR TITLE
support for NAD diagnostics, only relevant slave should act on request

### DIFF
--- a/lib/Config/Config.cpp
+++ b/lib/Config/Config.cpp
@@ -8,7 +8,9 @@
  * @param records A storage of records, so you can add records that's received from config
  */
 Config::Config(uint8_t ribID, Records &records)
-    : m_ribID(ribID),
+    : m_nad{},
+      m_nadHash{},
+      m_ribID(ribID),
       m_hostPort{},
       m_hostPortHash{},
       m_clientPort{},
@@ -157,7 +159,11 @@ void Config::verifyConfig()
             goodConfig = false;
             requestConfigItem(MESSAGE_SIZES);
         }
-
+        else if (m_nadHash.u16 != m_lastHash.u16)
+        {
+            goodConfig = false;
+            requestConfigItem(NAD);
+        }
         if (!goodConfig)
         {
             // Wait a little time in between
@@ -298,6 +304,14 @@ void Config::parseServerMessage()
         }
         m_nodeMode = static_cast<NodeModes>(m_packetBuffer.at(value(Offsets::PAYLOAD_START_OFFSET)));
         m_nodeModeHash = m_lastHash;
+        break;
+    case NAD:
+        if (1 != message_size)
+        {
+            return;
+        }
+        m_nad = static_cast<uint8_t>(m_packetBuffer.at(value(Offsets::PAYLOAD_START_OFFSET)));
+        m_nadHash = m_lastHash;
         break;
     default:
         break;

--- a/lib/Config/Config.hpp
+++ b/lib/Config/Config.hpp
@@ -87,6 +87,8 @@ public:
 public:
     NodeModes nodeMode() const { return m_nodeMode; }
 
+    uint8_t nad() const { return m_nad; }
+
     uint8_t ribID() const { return m_ribID; }
 
     uint16_t hostPort() const { return m_hostPort; }
@@ -118,7 +120,11 @@ private:
     static constexpr uint8_t MESSAGE_SIZES = (1u << 2u); // 4
     static constexpr uint8_t NODE_MODE = (1u << 3u);     // 8
     static constexpr uint8_t HEART_BEAT = (1u << 4u);    // 16
+    static constexpr uint8_t NAD = (1u << 5u);           // 64
     static constexpr uint8_t LOGGER = 0x60;              // 96
+
+    uint8_t m_nad = 0;          // This is intended for filtering diagnostic request. To selectively only answer with on lin client.
+    DoubleByte m_nadHash;
 
     uint8_t m_ribID;            // This is calculated locally and part of the message header
     AsyncUDP udpClientSender;   // Udp-client that sends data to signal broker

--- a/lib/Config/Config.hpp
+++ b/lib/Config/Config.hpp
@@ -120,7 +120,7 @@ private:
     static constexpr uint8_t MESSAGE_SIZES = (1u << 2u); // 4
     static constexpr uint8_t NODE_MODE = (1u << 3u);     // 8
     static constexpr uint8_t HEART_BEAT = (1u << 4u);    // 16
-    static constexpr uint8_t NAD = (1u << 5u);           // 64
+    static constexpr uint8_t NAD = (1u << 5u);           // 32
     static constexpr uint8_t LOGGER = 0x60;              // 96
 
     uint8_t m_nad = 0;          // This is intended for filtering diagnostic request. To selectively only answer with on lin client.

--- a/lib/LinUdpGateway/LinUdpGateway.hpp
+++ b/lib/LinUdpGateway/LinUdpGateway.hpp
@@ -13,7 +13,7 @@ class Record;
 class LinUdpGateway {
     enum class DiagnosticFrameId : uint8_t {
         MasterRequest = 60,
-        SlaveRequest = 61
+        SlaveResponse = 61
     };
 
 public:
@@ -46,11 +46,13 @@ private:
     void runSlave();
 
 private:
+    boolean is_request_intened_for_this_slave(int id);
     AsyncUDP m_udpClient;
     AsyncUDP m_udpListen;
     Lin m_lin;
     Config *m_config;
     Records *m_records;
+    int m_last_seen_nad;
 
     std::array<uint8_t, UDP_TX_PACKET_MAX_SIZE_CUSTOM> _packetBuffer{};
     int m_packetBufferLength{};


### PR DESCRIPTION
The idea here is to prevent the incorrect slave to reply to a diagnostics query made to "another" slave.

1. Clients gets configuration, `nad` in now a part of the configuration
2. client stores m_last_seen_nad. This is part of the `DiagnosticFrameId::MasterRequest`, more specifically the first byte of the payload.
3. once `DiagnosticFrameId::SlaveResponse` appears the client should only respond if the `m_last_seen_nad` matched the configured `nad`, from step (1)
4. If not intended for this client, nothing should be emitted.

@niclaslind - does this make sense to you? 