### PR TITLE
Slave send heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,14 @@ When you have uploaded the firmware to your ESP32-devices and assinged them with
       "schedule_autostart": false
 }
 ```
+
+### Debug
+
+Logging is by default output to serial 
+```
+constexpr bool LOG_TO_SERIAL = true;
+```
+To output logs in signalbroker do
+```
+constexpr bool LOG_TO_SERIAL = false;
+```

--- a/lib/LinUdpGateway/LinUdpGateway.cpp
+++ b/lib/LinUdpGateway/LinUdpGateway.cpp
@@ -84,6 +84,8 @@ uint8_t LinUdpGateway::synchHeader() {
         //    Serial.printf("FrameBreak: %d, FrameSynch: %d, FrameId: %d\n",
         //    frameBreak, frameSynch, frameId);
 
+        synchTries++;
+     
         if (bytesReceived != bytesExpected) {
             std::array<char, 100> message{};
             sprintf(message.data(),
@@ -91,10 +93,14 @@ uint8_t LinUdpGateway::synchHeader() {
                     "synchTries: %d",
                     bytesExpected, bytesReceived, synchTries);
             m_config->log(message.data());
+
+            // don't get stuck here, return frame_id with failing partiy, 
+            // continue looping.
+            frameId = BAD_ID_BYTE;
+            break;
         }
 
         match = (frameBreak == BREAK) && (frameSynch == SYN_FIELD);
-        synchTries++;
     }
 
     m_config->incrementSynchedPackages();

--- a/lib/LinUdpGateway/LinUdpGateway.hpp
+++ b/lib/LinUdpGateway/LinUdpGateway.hpp
@@ -57,6 +57,7 @@ private:
 
     static constexpr uint8_t BREAK = 0x00;
     static constexpr uint8_t SYN_FIELD = 0x55;
+    static constexpr uint8_t BAD_ID_BYTE = 0x00;
 
     // this is used by the master to send lin BREAK
     // on lin 14, 3 is fine. 2 results in some timeout

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@
 #include "EthernetClient.hpp"
 #include "LinUdpGateway.hpp"
 
-constexpr uint8_t rib_id = 4;
+constexpr uint8_t rib_id = 7;
 
 EthernetClient ethClient{};
 Records records{};


### PR DESCRIPTION
Client should leave match loop if there isn't any traffic.

Modification lets the loop return a **BAD_ID_BYTE** causing the loop to fall through, opening the ability for the client to communicate with server.