### PR TITLE
add watchdog

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@
 #include "Records.hpp"
 #include "EthernetClient.hpp"
 #include "LinUdpGateway.hpp"
+#include "esp_system.h"
 
 constexpr uint8_t rib_id = 7;
 
@@ -39,11 +40,29 @@ Records records{};
 Config config{rib_id, records};
 LinUdpGateway linUdpGateway{Serial1, config, records};
 
+const int wdtTimeout = 5000; //time in ms to trigger the watchdog
+hw_timer_t *timer = NULL;
+
+void resetModule()
+{
+    // if this happens we need to emit 
+    // console.log("some meningful information") once the settings are restored and system is operational gaain
+    // to inform the server that we had an unexpected reboot.
+    // ets_printf("reboot\n");
+    esp_restart();
+}
+
 void setup()
 {
     Serial.begin(115200);
     Serial1.begin(19200);
     ethClient.connect(&config);
+
+    // set up watchdog 
+    timer = timerBegin(0, 80, true);                  //timer 0, div 80
+    timerAttachInterrupt(timer, &resetModule, true);  //attach callback
+    timerAlarmWrite(timer, wdtTimeout * 1000, false); //set time in us
+    timerAlarmEnable(timer);
 
     // Init configuration
     config.init();
@@ -52,6 +71,7 @@ void setup()
 void loop()
 {
     // Get configuration from server and send heartbeat
+    timerWrite(timer, 0); //reset timer (feed watchdog)
     config.run();
 
     if (!linUdpGateway.connected())


### PR DESCRIPTION
Is operational but labeled WIP,

to be considered,
- [ ] set timeout to some sensible value
- [ ] once the system is up and running message should be emitted with hopefully useful information to the running server so that it leaves traces in the log.

https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/wdts.html

might be useful (on the topic)
https://github.com/espressif/esp-gdbstub (not for esp32)
https://github.com/espressif/esp-gdbstub/issues/15#issuecomment-707746973 (support for debug over usb in espressif)